### PR TITLE
XhprofDriver multiply nested start/stop calls preventing

### DIFF
--- a/src/Driver/XhprofDriver.php
+++ b/src/Driver/XhprofDriver.php
@@ -8,11 +8,18 @@ use SpiralPackages\Profiler\Profiler;
 
 final class XhprofDriver implements DriverInterface
 {
+    /** @var int Preventing multiple nested calls. */
+    private static int $nestedCalls = 0;
+
     /** @psalm-suppress UndefinedConstant */
     private const DEFAULT_FLAGS = XHPROF_FLAGS_MEMORY | XHPROF_FLAGS_CPU | XHPROF_FLAGS_NO_BUILTINS;
 
     public function start(array $context = [], int $flags = self::DEFAULT_FLAGS): void
     {
+        if (self::$nestedCalls++ > 0) {
+            return;
+        }
+
         $options = [
             'ignored_functions' => ['xhprof_disable', 'SpiralPackages\Profiler\Driver\XhprofDriver::end'],
         ];
@@ -30,6 +37,10 @@ final class XhprofDriver implements DriverInterface
 
     public function end(): array
     {
+        if (--self::$nestedCalls > 0) {
+            return [];
+        }
+
         /** @psalm-suppress UndefinedFunction */
         return \xhprof_disable();
     }

--- a/src/Driver/XhprofDriver.php
+++ b/src/Driver/XhprofDriver.php
@@ -42,6 +42,6 @@ final class XhprofDriver implements DriverInterface
         }
 
         /** @psalm-suppress UndefinedFunction */
-        return \xhprof_disable();
+        return \xhprof_disable() ?? [];
     }
 }


### PR DESCRIPTION
It is very similar to https://github.com/spiral/profiler/issues/16 but fixes case with sync queue and several instances of profiler

```php
// config/queue.php
return [
    // ...
    'interceptors' => [
        'consume' => [
            \Spiral\Profiler\ProfilerInterceptor::class,
        ],
    ],
];
```

How to kill worker
```php
 $queueManager->getConnection('sync')->push(MyJob::class);
```

In my case the `xhprof_enable` will be called 2 times. After the calling `xhprof_disable`  second time, segfault will occur.