### PR TITLE
FileStorage for store xhprof (or else) dumps.

### DIFF
--- a/src/Serializer/SerializerInterface.php
+++ b/src/Serializer/SerializerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpiralPackages\Profiler\Serializer;
+
+interface SerializerInterface
+{
+    public function serialize(array $profileData): string;
+}

--- a/src/Serializer/StandartSerializer.php
+++ b/src/Serializer/StandartSerializer.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpiralPackages\Profiler\Serializer;
+
+final class StandartSerializer implements SerializerInterface
+{
+    public function serialize(array $profileData): string
+    {
+        return \serialize($profileData);
+    }
+}

--- a/src/Storage/FileStorage.php
+++ b/src/Storage/FileStorage.php
@@ -28,7 +28,7 @@ final class FileStorage implements StorageInterface
                 throw new \RuntimeException(\sprintf('Fail to create folder `%s`', $this->dir));
             }
         }
-        $filepath = \sprintf("%s/%s.%s.%s", $this->dir, $appName, $date->getTimestamp(), $this->extension);
+        $filepath = \sprintf("%s/%s.%s.%s", $this->dir, $date->getTimestamp(), $appName, $this->extension);
         file_put_contents($filepath, $this->serializer->serialize($data));
     }
 }

--- a/src/Storage/FileStorage.php
+++ b/src/Storage/FileStorage.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+namespace SpiralPackages\Profiler\Storage;
+
+use SpiralPackages\Profiler\Serializer\SerializerInterface;
+use SpiralPackages\Profiler\Serializer\StandartSerializer;
+
+final class FileStorage implements StorageInterface
+{
+    /**
+     * @var string Save to directory.
+     */
+    private string $dir;
+
+    public function __construct(
+        private readonly SerializerInterface $serializer = new StandartSerializer(),
+        string $dir = '/tmp',
+        private readonly string $extension = 'xhprof'
+    ){
+        $this->dir = \rtrim($dir, DIRECTORY_SEPARATOR);
+    }
+
+    public function store(string $appName, array $tags, \DateTimeInterface $date, array $data): void
+    {
+        if (!\file_exists($this->dir)) {
+            if (!\mkdir(directory: $this->dir, recursive: true)) {
+                throw new \RuntimeException(\sprintf('Fail to create folder `%s`', $this->dir));
+            }
+        }
+        $filepath = \sprintf("%s/%s.%s.%s", $this->dir, $date->getTimestamp(), $appName, $this->extension);
+        file_put_contents($filepath, $this->serializer->serialize($data));
+    }
+}

--- a/src/Storage/FileStorage.php
+++ b/src/Storage/FileStorage.php
@@ -28,7 +28,7 @@ final class FileStorage implements StorageInterface
                 throw new \RuntimeException(\sprintf('Fail to create folder `%s`', $this->dir));
             }
         }
-        $filepath = \sprintf("%s/%s.%s.%s", $this->dir, $date->getTimestamp(), $appName, $this->extension);
+        $filepath = \sprintf("%s/%s.%s.%s", $this->dir, $appName, $date->getTimestamp(), $this->extension);
         file_put_contents($filepath, $this->serializer->serialize($data));
     }
 }

--- a/tests/src/Storage/FileStorageTest.php
+++ b/tests/src/Storage/FileStorageTest.php
@@ -25,7 +25,7 @@ final class FileStorageTest extends TestCase
             new \DateTimeImmutable('2024-05-13T00:00:00+00:00'),
             ['foo' => 'bar']
         );
-        self::assertFileExists('/tmp/1715558400.myapp.xhprof');
+        self::assertFileExists('/tmp/myapp.1715558400.xhprof');
     }
 
     /**
@@ -44,6 +44,6 @@ final class FileStorageTest extends TestCase
             new \DateTimeImmutable('2024-05-13T00:00:00+00:00'),
             ['foo' => 'bar']
         );
-        self::assertFileExists('/tmp/1715558400.myapp.dump');
+        self::assertFileExists('/tmp/myapp.1715558400.dump');
     }
 }

--- a/tests/src/Storage/FileStorageTest.php
+++ b/tests/src/Storage/FileStorageTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpiralPackages\Profiler\Tests\Storage;
+
+use SpiralPackages\Profiler\Serializer\StandartSerializer;
+use SpiralPackages\Profiler\Storage\FileStorage;
+use SpiralPackages\Profiler\Tests\TestCase;
+
+/**
+ * @coversDefaultClass \SpiralPackages\Profiler\Storage\FileStorage
+ */
+final class FileStorageTest extends TestCase
+{
+    /**
+     * @covers ::store
+     */
+    public function testStoreDefault(): void
+    {
+        $fs = new FileStorage();
+        $fs->store(
+            'myapp',
+            [],
+            new \DateTimeImmutable('2024-05-13T00:00:00+00:00'),
+            ['foo' => 'bar']
+        );
+        self::assertFileExists('/tmp/1715558400.myapp.xhprof');
+    }
+
+    /**
+     * @covers ::store
+     */
+    public function testStoreWithConstructorArguments(): void
+    {
+        $fs = new FileStorage(
+            serializer: new StandartSerializer(),
+            dir: '/tmp/',
+            extension: 'dump',
+        );
+        $fs->store(
+            'myapp',
+            [],
+            new \DateTimeImmutable('2024-05-13T00:00:00+00:00'),
+            ['foo' => 'bar']
+        );
+        self::assertFileExists('/tmp/1715558400.myapp.dump');
+    }
+}

--- a/tests/src/Storage/FileStorageTest.php
+++ b/tests/src/Storage/FileStorageTest.php
@@ -25,7 +25,7 @@ final class FileStorageTest extends TestCase
             new \DateTimeImmutable('2024-05-13T00:00:00+00:00'),
             ['foo' => 'bar']
         );
-        self::assertFileExists('/tmp/myapp.1715558400.xhprof');
+        self::assertFileExists('/tmp/1715558400.myapp.xhprof');
     }
 
     /**
@@ -44,6 +44,6 @@ final class FileStorageTest extends TestCase
             new \DateTimeImmutable('2024-05-13T00:00:00+00:00'),
             ['foo' => 'bar']
         );
-        self::assertFileExists('/tmp/myapp.1715558400.dump');
+        self::assertFileExists('/tmp/1715558400.myapp.dump');
     }
 }


### PR DESCRIPTION
I need to see dump by [xhprof html](https://github.com/phacility/xhprof/tree/master/xhprof_html).
This FileStorage will help me to dump profiles data to file.

To use this in spiral/framework we need bootloader like this.

```php

use Spiral\Boot\Bootloader\Bootloader;
use SpiralPackages\Profiler\Driver\DriverInterface;
use SpiralPackages\Profiler\Driver\XhprofDriver;
use SpiralPackages\Profiler\Serializer\StandartSerializer;
use SpiralPackages\Profiler\Storage\FileStorage;
use SpiralPackages\Profiler\Storage\StorageInterface;

final class ProfilerBootloader extends Bootloader
{
    public function defineBindings(): array
    {
        return [
            StorageInterface::class => static fn() => new FileStorage(
                serializer: new StandartSerializer(),
                dir: '/profiles',
                extension: 'xhprof',
            ),
            DriverInterface::class => static fn() => new XhprofDriver(),
        ];
    }
}
```

docker-compose for my use
```yaml
services:
  myapp:
    #... 
    volumes:
      - xhprof-profiles:/profiles
  
  xhprof-ui:
    image: tuimedia/xhprof-docker:0.9.4
    volumes:
      - xhprof-profiles:/profiles
    ports:
      - "8080:80"


volumes:
  xhprof-profiles: ~
```